### PR TITLE
[Task-43591819] - Add logic to use recommended vhdSize when vhdSize is not provided by user

### DIFF
--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -423,7 +423,7 @@ int main(int argc, char * argv[])
                         {
                             std::uintmax_t size = std::filesystem::file_size(packageSourcePath);
                             size = size / (1024 * 1024); //converting bytes into MBs
-                            vhdSize = size * 4; //assuming minimum VHD size to be 4x of source package size
+                            vhdSize = size * 4; //assuming minimum VHD size to be 4x of source package size in MB
                         }
 
                         std::wstring driveLetter;

--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -418,16 +418,16 @@ int main(int argc, char * argv[])
                     }
                     else
                     {
-                        if (cli.GetVHDSize() == 0)
+                        ULONGLONG vhdSize = cli.GetVHDSize();
+                        if (vhdSize == 0)
                         {
-                            std::wcout << std::endl;
-                            std::wcout << "VHD size was not specified. Please provide a vhd size in MB using the -vhdSize option" << std::endl;
-                            std::wcout << std::endl;
-                            return E_INVALIDARG;
+                            std::uintmax_t size = std::filesystem::file_size(packageSourcePath);
+                            size = size / (1024 * 1024); //converting bytes into MBs
+                            vhdSize = size * 4; //assuming minimum VHD size to be 4x of source package size
                         }
 
                         std::wstring driveLetter;
-                        HRESULT hrCreateVHD = MsixCoreLib::CreateAndMountVHD(unpackDestination, cli.GetVHDSize(), fileType == WVDFileType::VHD,  driveLetter);
+                        HRESULT hrCreateVHD = MsixCoreLib::CreateAndMountVHD(unpackDestination, vhdSize, fileType == WVDFileType::VHD,  driveLetter);
                         if (FAILED(hrCreateVHD))
                         {
                             std::wcout << std::endl;


### PR DESCRIPTION
**- What issue your PR is related to.**
Make vhdSize argument as optional for unpack command. When vhdSize will not be provided, 4x of source package size in MB will be used as recommended size of vhd.

**- What change your PR adds.**
Logic to check if vhdSize is not provided and then calculating the recommended vhdSize.

**- How you tested your change.**
Checked for a bunch of apps, what is the minimum vhdSize that those apps were able to get unpacked with and local app attach was working for them. Outcome of this exercise was recommended vhdSize, which came out to be 4x of source package size in MB.
After adding the logic to code, tested the vhdSize creation flow for a bunch of apps.
